### PR TITLE
An error occurs when the token not contains the token_principal_attri…

### DIFF
--- a/src/KeycloakGuard.php
+++ b/src/KeycloakGuard.php
@@ -43,8 +43,12 @@ class KeycloakGuard implements Guard
         }
 
         if ($this->decodedToken) {
+            $tokenAttribute = null;
+            if (property_exists($this->decodedToken, $this->config['token_principal_attribute'])) {
+                $tokenAttribute = $this->decodedToken->{$this->config['token_principal_attribute']};
+            }
             $this->validate([
-                $this->config['user_provider_credential'] => $this->decodedToken->{$this->config['token_principal_attribute']}
+                $this->config['user_provider_credential'] => $tokenAttribute
             ]);
         }
     }


### PR DESCRIPTION
…bute

This can happen if I need to support both access tokens received with the standard Authorization Code Flow and access tokens received with the Client Credentials Grant. In the former case, I set the "email" field in the user_provider_credential and token_principal_attribute settings, but in the latter case, there is no email address in the token, but I handle this with the cusom retrieve method.

![image](https://github.com/user-attachments/assets/c78e4a60-8582-4159-b93b-032593a2c310)
